### PR TITLE
Fixed issue where passed options were ignored

### DIFF
--- a/lib/rdoc/rouge/formatter.rb
+++ b/lib/rdoc/rouge/formatter.rb
@@ -5,19 +5,21 @@ module RDoc
     class Formatter < ::RDoc::Markup::ToHtml
 
       def initialize(options={})
-        opts = ::RDoc::Options.new
-        opts.pipe = options.delete(:pipe) || false
+        # passed options
+        @passed_options = options
+        opts            = ::RDoc::Options.new
+        opts.pipe       = options.delete(:pipe) || false
 
         super opts, nil
       end
 
       def accept_verbatim verbatim
-        text = verbatim.text.rstrip
-
-        lexer = ::Rouge::Lexer.find_fancy(verbatim.format.to_s, text) || ::Rouge::Lexers::Text
+        text      = verbatim.text.rstrip
+        lexer     = ::Rouge::Lexer.find_fancy(verbatim.format.to_s, text) || ::Rouge::Lexers::Text
 
         formatter = ::Rouge::Formatters::HTML.new(
-          :css_class => "highlight #{lexer.tag}"
+          # Merged options passed into the initializer
+          @passed_options.merge({ :css_class => "highlight #{lexer.tag}"})
         )
 
         @res << formatter.format(lexer.lex(text))


### PR DESCRIPTION
After digging around we found out that the options are not getting passed into the formatter on line 20. This is related to the following issue in Glorify here: https://github.com/zzak/glorify/issues/12
